### PR TITLE
Remove a layer of curly braces in match

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ local None = adt.new()
 --]]
 
 local r = Some(3)
-local v = adt.match(r, {
+local v = adt.match(r,
   { Some, function(v)
     return v + 10
   end },
   { None, function()
     return 0
   end }
-})
+)
 
 print(v) --> 13
 ```

--- a/src/adt.lua
+++ b/src/adt.lua
@@ -43,10 +43,10 @@ local function new(name, ...)
   })
 end
 
-local match = function(e, t)
+local match = function(e, ...)
   -- e = adt
-  -- t = {{adt, fun}, ...}
-  for _, tup in ipairs(t) do
+  -- ... = {adt, fun}, ...
+  for _, tup in ipairs{...} do
     if tup[1] ^ e then
       return tup[2](table.unpack(e))
     end


### PR DESCRIPTION
Here is a suggestion to reduce the amount syntax in `adt.match` a little. It removes a layer of curly braces.

Maybe you have good reason for wanting to put the `{adt, fun}` pairs in an array. For example, to build the array outside of the `match` call:

```lua
local cases = {
 { Some, function(v)
    return v + 10
  end },
  { None, function()
    return 0
  end }
}

local v = adt.match(r, cases)
```

But that is not the usage pattern shown in the README, which is more like an inline switch/case.

If the expected most common pattern is as the README example, I think this proposed change may be attractive. And the less common pre-build array case can be accommodated by a `table.unpack`:

```lua
local v = adt.match(r, table.unpack(cases))
```